### PR TITLE
Relax HTTPoison version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule SafeURL.MixProject do
   # Dependencies
   defp deps do
     [
-      {:httpoison, "~> 1.8", optional: true},
+      {:httpoison, "~> 1.0 or ~> 2.0", optional: true},
       {:inet_cidr, "~> 1.0"},
       {:dns, "~> 2.2"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},


### PR DESCRIPTION
Closes https://github.com/slab/safeurl-elixir/issues/8

`SafeURL` uses `HTTPoison.get/3`, which exists in both 1.x and 2.x versions. It's also an optional dependency, so it makes sense to relax version constraint as much as possible and let users decide which version they want to use.