### PR TITLE
Update DNS module and DNSResolver behaviour

### DIFF
--- a/guides/migrating_to_1.0.md
+++ b/guides/migrating_to_1.0.md
@@ -28,3 +28,15 @@ iex> Application.put_env(:safeurl, :detailed_error, false)
 iex> SafeURL.validate("http://localhost")
 {:error, :restricted}
 ```
+
+### Change modules implementing `SafeURL.DNSResolver` behaviour
+
+If you have a module that implements `SafeURL.DNSResolver` behaviour, note that
+`DNSResolver.resolve/1` signature has changed. Specifically, the ok tuple should now
+always return a list of IPs. A single IP is not a valid return type:
+
+```elixir
+# DNS is the default implementation
+iex> DNS.resolve("wikipedia.org")
+{:ok, [{198, 35, 26, 96}]}
+```

--- a/lib/safeurl/dns_resolver.ex
+++ b/lib/safeurl/dns_resolver.ex
@@ -69,6 +69,5 @@ defmodule SafeURL.DNSResolver do
 
   """
 
-  @type resolution :: :inet.ip() | [:inet.ip()]
-  @callback resolve(host :: binary()) :: {:ok, resolution()} | {:error, atom()}
+  @callback resolve(host :: String.t()) :: {:ok, list()} | {:error, :inet_res.res_error()}
 end

--- a/lib/safeurl/safeurl.ex
+++ b/lib/safeurl/safeurl.ex
@@ -239,7 +239,7 @@ defmodule SafeURL do
       {:error, :einval} ->
         # TODO: safely handle multiple IPs/round-robin DNS
         case dns_module.resolve(hostname) do
-          {:ok, ips} -> ips |> List.wrap() |> List.first()
+          {:ok, [ip | _]} -> ip
           {:error, _reason} -> nil
         end
     end

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule SafeURL.MixProject do
     [
       {:httpoison, "~> 1.0 or ~> 2.0", optional: true},
       {:inet_cidr, "~> 1.0 and >= 1.0.6"},
-      {:dns, "~> 2.2"},
+      {:dns, "~> 2.4"},
       {:tesla, "~> 1.0", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]


### PR DESCRIPTION
I ran into a warning while generating docs for 1.0.0. The `:inet.ip()` type that `DNSResolver` was referencing did not exist. I could not find at what point this type existed in Erlang, but `DNS` library did use it in `DNS.resolve/4` spec [in version 2.2.0](https://hexdocs.pm/dns/2.2.0/DNS.html#resolve/4). Since then 2 versions have been released and the return type settled as `{:ok, list()} | {:error, :inet_res.res_error()}` in 2.4.0

This PR bumps `DNS` dependency to `~2.4` and changes `SafeURL.DNSResolver` behaviour to follow new spec.